### PR TITLE
HAL_ChibiOS: fix I2C transaction without stop condition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,4 +21,5 @@
 	url = git://github.com/ArduPilot/googletest
 [submodule "modules/ChibiOS"]
 	path = modules/ChibiOS
-	url = git://github.com/ArduPilot/ChibiOS.git
+	url = git://github.com/SergeyBokhantsev/ChibiOS.git
+	branch = 3.6-sb

--- a/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
+++ b/libraries/AP_HAL_ChibiOS/I2CDevice.cpp
@@ -287,7 +287,7 @@ bool I2CDevice::_transfer(const uint8_t *send, uint32_t send_len,
         if (ret != MSG_OK) {
             //restart the bus
             osalDbgAssert(I2CD[bus.busnum].i2c->state == I2C_READY || I2CD[bus.busnum].i2c->state == I2C_LOCKED, "i2cStart state");
-            i2cStop(I2CD[bus.busnum].i2c);
+            i2cSoftStop(I2CD[bus.busnum].i2c);
             osalDbgAssert(I2CD[bus.busnum].i2c->state == I2C_STOP, "i2cStart state");
             i2cStart(I2CD[bus.busnum].i2c, &bus.i2ccfg);
             osalDbgAssert(I2CD[bus.busnum].i2c->state == I2C_READY, "i2cStart state");


### PR DESCRIPTION
Start using i2cSoftStop() instead of i2cStop() so the peripheral
continues to be enabled and with non-gated clock.  This allows time for
the I2C peripheral to continue the ack or stop.

(cherry picked from commit 4abc8e17a69ae982b9d3ac5dc125860812242831)

Switch to forked ChibiOs branch